### PR TITLE
use C data types that can handle big numbers

### DIFF
--- a/ext/hungarian_algorithm_c/hungarian_algorithm_c.c
+++ b/ext/hungarian_algorithm_c/hungarian_algorithm_c.c
@@ -53,8 +53,8 @@ VALUE pairs(VALUE self, VALUE flattened_array_ruby, VALUE row_size_val) {
 
   int index;
   for (index = 0; index < array_size; index++) {
-    double element = 100 * NUM2DBL(rb_ary_entry(flattened_array_ruby, index));
-    int rounded_element = element;
+    long double element = 100 * NUM2DBL(rb_ary_entry(flattened_array_ruby, index));
+    long long int rounded_element = element;
     array_c[index] = rounded_element;
   }
 

--- a/lib/hungarian_algorithm_c.rb
+++ b/lib/hungarian_algorithm_c.rb
@@ -1,4 +1,4 @@
-require 'hungarian_algorithm_c.so'
+require_relative './hungarian_algorithm_c.so'
 
 module HungarianAlgorithmC
   class << self

--- a/lib/hungarian_algorithm_c/version.rb
+++ b/lib/hungarian_algorithm_c/version.rb
@@ -1,3 +1,3 @@
 module HungarianAlgorithmC
-  VERSION = '0.0.1'
+  VERSION = '0.0.2'
 end

--- a/spec/hungarian_algorithm_c_spec.rb
+++ b/spec/hungarian_algorithm_c_spec.rb
@@ -41,6 +41,22 @@ RSpec.describe HungarianAlgorithmC do
           [2, 1]
         ])
       end
+
+      context 'with very large numbers' do
+        let(:matrix_with_costs) { [
+          [4, 1, 7],
+          [Float::INFINITY, 3, 9],
+          [1, 2, 13]
+        ] }
+
+        it 'should output minimum cost pairs' do
+          should match_array([
+            [0, 2],
+            [1, 0],
+            [2, 1]
+          ])
+        end
+      end
     end
 
     context '4x4 array' do
@@ -58,6 +74,24 @@ RSpec.describe HungarianAlgorithmC do
           [2, 3],
           [3, 0]
         ])
+      end
+
+      context 'with very large numbers' do
+        let(:matrix_with_costs) { [
+          [Float::INFINITY, 3, 10000000000000000000000000000000000, 3],
+          [10, 2, Float::INFINITY, 6],
+          [10, 3, 34, Float::INFINITY],
+          [99999999999999999999999, 13, 15, 6000000000000000]
+        ] }
+
+        it 'should output minimum cost pairs' do
+          should match_array([
+            [0, 2],
+            [1, 1],
+            [2, 3],
+            [3, 0]
+          ])
+        end
       end
     end
   end


### PR DESCRIPTION
The gem would simply exit when it was thrown large numbers. This PR fixes that by using the right data types for large numbers. Removing the fix will result in not all tests running i.e. the first test run with the very large numbers will exit the suite.