### PR TITLE
remove multiplication by 100

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ HungarianAlgorithmC.find_pairings(costs)
 #=> [[0, 0], [1, 2], [2, 1]]
 ```
 
+**Note**: Your cost matrix should not have `Float::INFINITY` or _very very large_ numbers as those will not be interpreted appropriately [here](ext/hungarian_algorithm_c/hungarian_algorithm_c.c#56).
+
 ## Acknowledgements
 
 The C code uses the implementation by [Cyrill Stachniss](ext/hungarian_algorithm_c/libhungarian).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ HungarianAlgorithmC.find_pairings(costs)
 #=> [[0, 0], [1, 2], [2, 1]]
 ```
 
-**Note**: Your cost matrix should not have `Float::INFINITY` or _very very large_ numbers as those will not be interpreted appropriately [here](ext/hungarian_algorithm_c/hungarian_algorithm_c.c#56).
+**Note**: Your cost matrix should not have `Float::INFINITY` or _very very large_ numbers as those will not be interpreted appropriately [here](ext/hungarian_algorithm_c/hungarian_algorithm_c.c#L56).
 
 ## Acknowledgements
 

--- a/ext/hungarian_algorithm_c/hungarian_algorithm_c.c
+++ b/ext/hungarian_algorithm_c/hungarian_algorithm_c.c
@@ -53,7 +53,7 @@ VALUE pairs(VALUE self, VALUE flattened_array_ruby, VALUE row_size_val) {
 
   int index;
   for (index = 0; index < array_size; index++) {
-    long double element = 100 * NUM2DBL(rb_ary_entry(flattened_array_ruby, index));
+    long double element = NUM2DBL(rb_ary_entry(flattened_array_ruby, index));
     long long int rounded_element = element;
     array_c[index] = rounded_element;
   }

--- a/lib/hungarian_algorithm_c/version.rb
+++ b/lib/hungarian_algorithm_c/version.rb
@@ -1,3 +1,3 @@
 module HungarianAlgorithmC
-  VERSION = '0.0.2'
+  VERSION = '0.0.3'
 end

--- a/spec/hungarian_algorithm_c_spec.rb
+++ b/spec/hungarian_algorithm_c_spec.rb
@@ -25,6 +25,17 @@ RSpec.describe HungarianAlgorithmC do
           [0, 0]
         ])
       end
+
+      context 'matrix contains Floa::INFINITY' do
+        let(:matrix_with_costs) { [
+          [4, 3],
+          [3, Float::INFINITY]
+        ] }
+
+        it 'should not crash' do
+          should be_a Array
+        end
+      end
     end
 
     context '3x3 array' do
@@ -40,22 +51,6 @@ RSpec.describe HungarianAlgorithmC do
           [1, 2],
           [2, 1]
         ])
-      end
-
-      context 'with very large numbers' do
-        let(:matrix_with_costs) { [
-          [4, 1, 7],
-          [Float::INFINITY, 3, 9],
-          [1, 2, 13]
-        ] }
-
-        it 'should output minimum cost pairs' do
-          should match_array([
-            [0, 2],
-            [1, 0],
-            [2, 1]
-          ])
-        end
       end
     end
 
@@ -76,12 +71,12 @@ RSpec.describe HungarianAlgorithmC do
         ])
       end
 
-      context 'with very large numbers' do
+      context 'with large numbers' do
         let(:matrix_with_costs) { [
-          [Float::INFINITY, 3, 10000000000000000000000000000000000, 3],
-          [10, 2, Float::INFINITY, 6],
-          [10, 3, 34, Float::INFINITY],
-          [99999999999999999999999, 13, 15, 6000000000000000]
+          [1_000_000, 2_000_000, 3, 3_000_000],
+          [9_000_000, 1, 4_000_000, 5_000_000],
+          [2_000_000, 1_000_000, 1_000_000, 4],
+          [1, 8_000_000, 3_000_000, 44]
         ] }
 
         it 'should output minimum cost pairs' do


### PR DESCRIPTION
- removed multiplication by 100 in C interpretation of Ruby numbers
- cleaned up specs to not: 
  - don't ensure success on `Float::INFINITY` - just ensure that it doesn't crash
  - ensure success on relatively large numbers, not **very** large numbers
- updated README.md
- bumped version